### PR TITLE
feat/#7 : oauth2 전체 틀 구현, 카카오 oauth2 구현 완료

### DIFF
--- a/src/main/java/com/cloudbread/auth/jwt/JwtAuthorizationFilter.java
+++ b/src/main/java/com/cloudbread/auth/jwt/JwtAuthorizationFilter.java
@@ -1,0 +1,91 @@
+package com.cloudbread.auth.jwt;
+
+import com.cloudbread.auth.oauth2.CustomOAuth2User;
+import com.cloudbread.domain.user.domain.entity.User;
+import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+// JWT 검증 필터
+// 1. 헤더에서 accessToken 추출, 2. 토큰 검증, 3. 유효하면 사용자정보를 SecurityContextHolder에 세팅
+// 그러면, 이후 컨트롤러에서 @AuthenticationPrincipal에서 저장했던 사용자 정보를 꺼내쓸 수 있음
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthorizationFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+        log.info("JwtAuthorizationFitler 이건 언제 호출해 ??");
+        log.info("JwtAuthorizationFilter 요청 URI: {}", request.getRequestURI());
+
+        String header = request.getHeader("Authorization");
+
+        // 인증헤더 Bearer가 없다면, 다음 필터로 넘김
+        if (header == null || !header.startsWith("Bearer ")){
+            filterChain.doFilter(request, response);
+
+            log.info("JwtAuthorizationFilter 1 ");
+            return ;
+        }
+
+        log.info("header :: {}, header.substring(7) :: {}", header, header.substring(7));
+        String accessToken = header.substring(7);
+
+
+        // 토큰 만료 여부 확인, 만료 시 다음 필터로 넘기지 않음
+        try {
+            jwtUtil.isExpired(accessToken);
+        } catch (ExpiredJwtException e){
+
+            // response status code + msg
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().print("access token expired");
+
+            log.info("JwtAuthorizationFilter 2 ");
+            return;
+        }
+
+        // 토큰이 accessToken 종류인지 확인
+        String tokenCategory = jwtUtil.getTokenCategory(accessToken);
+
+        if (!tokenCategory.equals("accessToken")){
+            //response status code
+            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+            response.getWriter().print("invalid access token");
+
+            log.info("JwtAuthorizationFilter 3 ");
+            return;
+        }
+
+        // userId와 email 값 추출
+        Long userId = jwtUtil.getUserId(accessToken);
+        String email = jwtUtil.getEmail(accessToken);
+
+        User user = User.createUserForSecurityContext(userId, email);
+
+        CustomOAuth2User customOAuth2User = new CustomOAuth2User(user);
+
+        // 스프링 시큐리티 인증 토큰 생성
+        UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken = new UsernamePasswordAuthenticationToken(
+                customOAuth2User, null, customOAuth2User.getAuthorities());
+
+        // 생성한 인증 정보를 SecurityContext에 설정
+        SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+
+        log.info("JwtAuthorizationFilter 4 ");
+
+        filterChain.doFilter(request, response);
+
+    }
+}

--- a/src/main/java/com/cloudbread/auth/jwt/JwtUtil.java
+++ b/src/main/java/com/cloudbread/auth/jwt/JwtUtil.java
@@ -1,0 +1,74 @@
+package com.cloudbread.auth.jwt;
+
+import io.jsonwebtoken.Jwts;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Component
+public class JwtUtil {
+    private SecretKey secretKey;
+
+    // 시크릿 키를 암호화하여, 키 생성
+    public JwtUtil(@Value("${jwt.secret}") String secret){
+        this.secretKey = new SecretKeySpec(
+                secret.getBytes(StandardCharsets.UTF_8),
+                Jwts.SIG.HS256.key().build().getAlgorithm()
+        );
+    }
+
+    public String createAccessToken(String tokenCategory, Long userId, String email, Long expiredMs){
+        return Jwts.builder()
+                .claim("tokenCategory", tokenCategory) // accessToken
+                .claim("userId", userId)
+                .claim("email", email)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String createRefreshToken(String tokenCategory, Long userId, Long expiredMs){
+        return Jwts.builder()
+                .claim("tokenCategory", tokenCategory) // refreshToken
+                .claim("userId", userId)
+                .issuedAt(new Date(System.currentTimeMillis()))
+                .expiration(new Date(System.currentTimeMillis() + expiredMs))
+                .signWith(secretKey)
+                .compact();
+    }
+
+    public String getTokenCategory(String token){
+        return Jwts.parser().setSigningKey(secretKey).build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("tokenCategory", String.class);
+    }
+
+    public String getEmail(String token){
+        return Jwts.parser().setSigningKey(secretKey).build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("email", String.class);
+    }
+
+    public Long getUserId(String token){
+        return Jwts.parser().setSigningKey(secretKey).build()
+                .parseClaimsJws(token)
+                .getBody()
+                .get("userId", Long.class);
+    }
+
+    public Boolean isExpired(String token){
+        return Jwts.parser().verifyWith(secretKey).build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getExpiration()
+                .before(new Date());
+    }
+
+}

--- a/src/main/java/com/cloudbread/auth/oauth2/CustomOAuth2User.java
+++ b/src/main/java/com/cloudbread/auth/oauth2/CustomOAuth2User.java
@@ -1,0 +1,60 @@
+package com.cloudbread.auth.oauth2;
+
+import com.cloudbread.domain.user.domain.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+
+// OAuth2User 인터페이스를 구현하면, Spring Security사 이 객체를 SecurityContext에 넣어줌
+// 여기서 오버라이딩한 메서드들은, 스프링 시큐리티가 내부적으로 사용자 정보를 꺼낼 때 호출한다
+@RequiredArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+    private User user;
+
+    public CustomOAuth2User(User user){
+        this.user = user;
+    }
+
+    // oauth2 공급자(google, kakao..)로부터 받은 원본 사용자 데이터를 담은 map (email,..)
+    @Override
+    public Map<String, Object> getAttributes() {
+        return null;
+    }
+
+    // 위 getAttributes()에 있는 값들 중, 특정 키만 꺼내고 싶을 때
+    // ex) getAttribute("email"), getAttributes가 null이면 무용지물
+    @Override
+    public <A> A getAttribute(String name) {
+        return OAuth2User.super.getAttribute(name);
+    }
+
+    // 현재 로그인한 사용자가 가진 권한(role) 목록 반환
+    // ex: ROLE_USER, ROLE_ADMIN
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.singletonList(new SimpleGrantedAuthority("ROLE_USER"));
+    }
+
+    // 사용자의 고유 식별자 반환, 보통 email나 id ..
+    @Override
+    public String getName() {
+        return user.getEmail();
+    }
+
+    public User getUser(){
+        return user;
+    }
+
+    public Long getUserId(){
+        return user.getId();
+    }
+
+    public String getEmail(){
+        return user.getEmail();
+    }
+}

--- a/src/main/java/com/cloudbread/auth/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/cloudbread/auth/oauth2/CustomOAuth2UserService.java
@@ -1,0 +1,81 @@
+package com.cloudbread.auth.oauth2;
+
+import com.cloudbread.auth.oauth2.dto.KaKaoResponse;
+import com.cloudbread.auth.oauth2.dto.OAuth2Response;
+import com.cloudbread.domain.user.domain.entity.User;
+import com.cloudbread.domain.user.domain.enums.OauthProvider;
+import com.cloudbread.domain.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+// OAuth2 제공자(카카오,구글..)로부터 제공받은 사용자 정보를, 우리 서비스에 맞게 가공, 변환
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        log.info("CustomOAuth2UserService는 왔음 ??");
+
+
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        log.info("CustomOAuth2UserService :: {}", oAuth2User);
+        log.info("oAuthUser.getAttributes :: {}", oAuth2User.getAttributes());
+
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        log.info("registrationId :: {}", registrationId);
+
+        OAuth2Response oAuth2Response = null;
+
+        switch (registrationId) {
+            case "kakao":
+                oAuth2Response = new KaKaoResponse(oAuth2User.getAttributes());
+                break;
+//            case "google":
+//                oAuth2Response = new GoogleResponse(oAuth2User.getAttributes());
+//                break;
+//            case "naver":
+//                oAuth2Response = new NaverResponse(oAuth2User.getAttributes());
+//                break;
+            default:
+                throw new OAuth2AuthenticationException("지원하지 않는 OAuth Provider입니다.");
+        }
+
+        // OAuth2User로부터 가져온 정보를 바탕으로, 회원가입 or 로그인
+
+        // DB에 해당 유저가 있는지 판단
+        Optional<User> foundUser = userRepository.findByEmail(oAuth2Response.getEmail());
+
+        // DB에 유저 없으면 - 회원가입
+        if (foundUser.isEmpty()){
+            log.info("user가 없어서 회원가입했어요.");
+            User user = User.createUserFirstOAuth(
+                    oAuth2Response.getEmail(),
+                    oAuth2Response.getNickName(),
+                    oAuth2Response.getProfileImage(),
+                    OauthProvider.fromRegistrationId(registrationId)
+            );
+
+            userRepository.save(user);
+
+            return new CustomOAuth2User(user);
+        } else {
+            log.info("이미 해당 유저가 회원가입에 존재해서, CustomOAuth2User만 채워둡니다.");
+            // DB에 유저 존재하면 - 로그인 진행 (이때 로그인 처리는 안하고, OAuth2LoginSuccessHandler에서 담당함)
+            User user = foundUser.get();
+
+            return new CustomOAuth2User(user);
+        }
+
+    }
+}

--- a/src/main/java/com/cloudbread/auth/oauth2/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/cloudbread/auth/oauth2/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,87 @@
+package com.cloudbread.auth.oauth2;
+
+import com.cloudbread.auth.jwt.JwtUtil;
+import com.cloudbread.auth.token.Token;
+import com.cloudbread.auth.token.TokenRepository;
+import com.cloudbread.domain.user.domain.entity.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.Optional;
+
+// 카카오 로그인 성공 시, 콜백 핸들러
+// 1. JWT 토큰 발급
+// - 이때, JWT payload는 보안상 최소한의 정보(userId, email)만 담겠다
+// 2. refreshToken만 DB에 저장
+// 3. JSON 응답으로, accessToken과 refreshToken 을 반환해준다.
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2LoginSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    private final JwtUtil jwtUtil;
+    private final TokenRepository tokenRepository;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+                                        Authentication authentication) throws IOException, ServletException  {
+        log.info("OAuth2LoginSuccessHandler는 왔음 ??");
+        log.info("onAuthenticationSuccess 요청 URI: {}", request.getRequestURI());
+
+        // 1. CustomOAuth2UserService에서 설정한 OAuth2User 정보 가져오기
+        CustomOAuth2User customUserDetails = (CustomOAuth2User) authentication.getPrincipal();
+
+        User user = customUserDetails.getUser();
+        Long userId = customUserDetails.getUserId();
+        String email = customUserDetails.getEmail();
+
+        log.info(" >>>> OAuth2LoginSuccessHandler :: user, userId, email:: {} {} {}", user, userId, email);
+
+        // 2. 1)의 사용자 정보를 담아, accessToken과 refreshToken 발행
+        String accessToken = jwtUtil.createAccessToken("accessToken", userId, email, 30 * 60 * 1000L);// 유효기간 30분
+        String refreshToken = jwtUtil.createRefreshToken("refreshToken", userId, 30 * 24 * 60 * 60 * 1000L);    // 유효기간 30일
+
+        // 3. refreshToken을 DB에 저장 -- user1명당, token 1개로 제한해놓아서 업데이트 로직으로 변경
+        Optional<Token> existingToken = tokenRepository.findByUserId(userId);
+
+        if (existingToken.isPresent()){
+            log.info("이미 토큰이 존재합니다. 새로운 토큰으로 업데이트합니다!");
+            Token token = existingToken.get();
+            token.update(refreshToken, LocalDateTime.now().plusDays(30));
+
+            tokenRepository.save(token);
+
+        } else { // 기존 토큰 존재하지 않음
+            Token refreshTokenEntity = Token.toEntity(user, refreshToken, LocalDateTime.now().plusDays(30));
+            tokenRepository.save(refreshTokenEntity);
+        }
+
+        // 4. JSON 응답으로, accessToken과 refreshToken 을 반환해준다.
+        response.setContentType("application/json");
+        response.setCharacterEncoding("utf-8");
+
+        ObjectMapper objectMapper = new ObjectMapper(); // 객체 -> json 문자열로 변환
+        String body = objectMapper.writeValueAsString(
+                Map.of(
+                        "accessToken", accessToken,
+                        "refreshToken", refreshToken
+                )
+        );
+
+       response.getWriter().write(body);
+
+
+
+    }
+}

--- a/src/main/java/com/cloudbread/auth/oauth2/dto/KaKaoResponse.java
+++ b/src/main/java/com/cloudbread/auth/oauth2/dto/KaKaoResponse.java
@@ -1,0 +1,38 @@
+package com.cloudbread.auth.oauth2.dto;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+// kakao oauth2 응답에서 필요한 정보를 추출하는 역할
+@RequiredArgsConstructor
+public class KaKaoResponse implements OAuth2Response {
+    private final Map<String, Object> attributes;
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getEmail() {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        return kakaoAccount.get("email").toString();
+    }
+
+    @Override
+    public String getNickName() {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        return properties.get("nickname").toString();
+    }
+
+    @Override
+    public String getProfileImage() {
+        Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
+        return properties.get("profile_image").toString();
+    }
+}

--- a/src/main/java/com/cloudbread/auth/oauth2/dto/OAuth2Response.java
+++ b/src/main/java/com/cloudbread/auth/oauth2/dto/OAuth2Response.java
@@ -1,0 +1,19 @@
+package com.cloudbread.auth.oauth2.dto;
+
+public interface OAuth2Response {
+    // 제공자 (ex. naver, kakao)
+    String getProvider();
+
+    // 제공자에서 발급해주는 아이디 (번호)
+    String getProviderId();
+
+    // 아래 이메일, 닉네임, 프로필이미지는 내가 카카오 developers에서 발급받겠다고 신청한 정보들이다
+    // 이메일
+    String getEmail();
+
+    // 닉네임
+    String getNickName();
+
+    // 프로필이미지
+    String getProfileImage();
+}

--- a/src/main/java/com/cloudbread/auth/token/Token.java
+++ b/src/main/java/com/cloudbread/auth/token/Token.java
@@ -1,0 +1,52 @@
+package com.cloudbread.auth.token;
+
+import com.cloudbread.domain.model.BaseEntity;
+import com.cloudbread.domain.user.domain.entity.User;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "token")
+@Getter
+public class Token extends BaseEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long tokenId;
+
+    @OneToOne(fetch = FetchType.LAZY) // 유저당 하나의 refreshToken을 가지도록 설정! (개발 단순 but, 디바이스별 토큰 발급 및 저장 불가!)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column
+    private String refreshToken;
+
+    private LocalDateTime expiredDate;
+
+    @Builder
+    public Token(User user, String refreshToken, LocalDateTime expiredDate) {
+        this.user = user;
+        this.refreshToken = refreshToken;
+        this.expiredDate = expiredDate;
+    }
+
+    // static method로 객체를 생성 - 생성 의도 파악 쉬웁
+    public static Token toEntity(User user, String refreshToken, LocalDateTime expiredDate){
+        return Token.builder()
+                .user(user)
+                .refreshToken(refreshToken)
+                .expiredDate(expiredDate)
+                .build();
+    }
+
+    public void update(String refreshToken, LocalDateTime expiredDate){
+        this.refreshToken = refreshToken;
+        this.expiredDate = expiredDate;
+    }
+
+}

--- a/src/main/java/com/cloudbread/auth/token/TokenRepository.java
+++ b/src/main/java/com/cloudbread/auth/token/TokenRepository.java
@@ -1,0 +1,9 @@
+package com.cloudbread.auth.token;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface TokenRepository extends JpaRepository<Token, Long> {
+    Optional<Token> findByUserId(Long userId);
+}

--- a/src/main/java/com/cloudbread/domain/user/domain/entity/User.java
+++ b/src/main/java/com/cloudbread/domain/user/domain/entity/User.java
@@ -36,11 +36,11 @@ public class User extends BaseEntity {
 
     private String nickname;
 
-    private String profile_image_url;
+    private String profileImageUrl;
 
     private int age;
 
-    @Column(name = "due_date", nullable = false)
+    @Column(name = "due_date")
     private LocalDate dueDate;
 
     @Column(precision = 5, scale = 2)
@@ -55,13 +55,13 @@ public class User extends BaseEntity {
     private boolean activated; // soft-delete 구현, 삭제 구현 시 activated = 0 (false)
 
     @Builder
-    public User(Long id, String email, OauthProvider oauthProvider, String nickname, String profile_image_url, int age,
+    public User(Long id, String email, OauthProvider oauthProvider, String nickname, String profileImageUrl, int age,
                 LocalDate dueDate, BigDecimal height, BigDecimal weight, String otherHealthFactors, boolean activated) {
         this.id = id;
         this.email = email;
         this.oauthProvider = oauthProvider;
         this.nickname = nickname;
-        this.profile_image_url = profile_image_url;
+        this.profileImageUrl = profileImageUrl;
         this.age = age;
         this.dueDate = dueDate;
         this.height = height;
@@ -69,6 +69,27 @@ public class User extends BaseEntity {
         this.otherHealthFactors = otherHealthFactors;
         this.activated = activated;
     }
+
+    // JwtAuthorizationFilter에서 스프링컨텍스트에 넣을 유저 식별 정보 생성 함수
+    public static User createUserForSecurityContext(Long userId, String email){
+        return User.builder()
+                .id(userId)
+                .email(email)
+                .build();
+    }
+
+    // 첫번째 회원가입 -> oauth2 회원가입 (email, oauth_provider, nickname, profile_image_url // activated)
+    public static User createUserFirstOAuth(String email, String nickname, String profileImageUrl, OauthProvider oauthProvider) {
+        return User.builder()
+                .email(email)
+                .oauthProvider(oauthProvider)
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .activated(true) // soft-delete를 위한 필드 (삭제 구현 시, activated = 0)
+                .build();
+
+    }
+
 
     // User 도메인 관련 비즈니스 로직
     public boolean isAdult(){ // 테스트

--- a/src/main/java/com/cloudbread/domain/user/domain/enums/OauthProvider.java
+++ b/src/main/java/com/cloudbread/domain/user/domain/enums/OauthProvider.java
@@ -2,6 +2,15 @@ package com.cloudbread.domain.user.domain.enums;
 
 // 가장 최근 로그인할 때 사용된 oauth2 provider
 public enum OauthProvider {
-    GOOGLE, NAVER, KAKAO
+    GOOGLE, NAVER, KAKAO;
+
+    public static OauthProvider fromRegistrationId(String registrationId){
+        switch (registrationId.toLowerCase()) {
+            case "kakao": return KAKAO;
+//            case "google": return GOOGLE;
+//            case "naver": return NAVER;
+            default: throw new IllegalArgumentException("Unknown registrationId: " + registrationId);
+        }
+    }
 
 }

--- a/src/main/java/com/cloudbread/domain/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/cloudbread/domain/user/domain/repository/UserRepository.java
@@ -3,6 +3,10 @@ package com.cloudbread.domain.user.domain.repository;
 import com.cloudbread.domain.user.domain.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByEmail(String email);
 
 }

--- a/src/main/java/com/cloudbread/global/config/CorsConfig.java
+++ b/src/main/java/com/cloudbread/global/config/CorsConfig.java
@@ -1,0 +1,7 @@
+package com.cloudbread.global.config;
+
+import org.springframework.context.annotation.Configuration;
+
+// @Configuration
+public class CorsConfig {
+}

--- a/src/main/java/com/cloudbread/global/config/SecurityConfig.java
+++ b/src/main/java/com/cloudbread/global/config/SecurityConfig.java
@@ -1,8 +1,66 @@
 package com.cloudbread.global.config;
 
+import com.cloudbread.auth.jwt.JwtAuthorizationFilter;
+import com.cloudbread.auth.jwt.JwtUtil;
+import com.cloudbread.auth.oauth2.CustomOAuth2UserService;
+import com.cloudbread.auth.oauth2.OAuth2LoginSuccessHandler;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.cors.CorsConfigurationSource;
 
-// @Configuration
+@Configuration
+@EnableWebSecurity // security 활성화 어노테이션
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final CustomOAuth2UserService customOAuth2UserService;
+    private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
+    private final JwtUtil jwtUtil;
+
+    private final CorsConfigurationSource corsConfigurationSource;
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .cors(AbstractHttpConfigurer::disable) // 아직 백엔드만 이기에 cors 비활성화
+                .csrf(AbstractHttpConfigurer::disable) // csrf 방어 기능 비활성화 (jwt 토큰을 사용할 것이기에)
+                .formLogin(AbstractHttpConfigurer::disable) // 시큐리티 폼 로그인 비활성화
+                .httpBasic(AbstractHttpConfigurer::disable) // HTTP Basic 인증 비활성화
+                // oauth2 로그인
+                //  - userInfoEndPoint에서 사용자 정보 불러오고
+                //  - successHandler에서 로그인 성공 시 JWT 생성 및 반환로직
+                .oauth2Login(oauth2 -> oauth2
+                        .userInfoEndpoint(userInfoEndpoint ->
+                                userInfoEndpoint.userService(customOAuth2UserService))
+                        .successHandler(oAuth2LoginSuccessHandler)
+
+                )
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS) // 세션 사용 X (jwt토큰)
+                )
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/swagger-ui/**", "/v3/api-docs/**",
+                                "/api/users/example/{user-id}", // 패키지 구조 예제 코드
+                                "/oauth2/authorization/kakao", // 카카오 로그인 요청
+                                "/login/oauth2/code/**" // 카카오 인증 콜백
+                        )
+                        .permitAll()
+                        .anyRequest().authenticated() // 그외 요청은 허가된 사람만 인가
+
+                )
+                // jwtFilter
+                .addFilterBefore(new JwtAuthorizationFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+
+    }
 
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,24 +1,11 @@
 # spring config
 spring:
-  # mysql
-  datasource:
-    url: jdbc:mysql://localhost:3307/GoormBbang?useSSL=false&allowPublicKeyRetrieval=true
-    username: root
-    password: 1234
-    driver-class-name: com.mysql.cj.jdbc.Driver
-
-  # jpa
-  jpa:
-    hibernate:
-      ddl-auto: update
-    properties:
-      hibernate:
-        dialect: org.hibernate.dialect.MySQLDialect
-    show-sql: true
-    format_sql: true
+  config:
+    import: application-secret.yml
 
 
 # Swagger config
+# 로컬 Swagger 접근 url -> http://localhost:8080/swagger-ui/index.html
 springdoc:
   packages-to-scan: com.cloudbread.domain
   default-consumes-media-type: application/json;charset=UTF-8


### PR DESCRIPTION


## 📌 연관 이슈
- issue #7 

## 🌱 PR 요약
- spring security, jwt, oauth2 의 전체적인 흐름을 구현했습니다.
- 카카오 oauth2 로그인이 성공한 상태입니다. (아직 @AuthenticationPrincipal 샘플 컨트롤러 적용 전)

## ❗️리뷰어들께
- auth2 패키지 안에 관련 사항을 최대한 넣어서, 해당 패키지 위주로 검토해주시길 바랍니다.
<img width="366" height="392" alt="image" src="https://github.com/user-attachments/assets/05101abd-015a-41c0-8d56-04a4a4a5da3f" />

- 그외에 참고할 코드는, global/config의 SecurityConfig 파일입니다. 
- 또한 application.yml과 application-secret.yml 파일을 분리하고, application-secret.yml 파일은 추후 노션에 공유할 예정입니다.
