### PR TITLE
[feat/#7] : UserRestController에 @AuthenticationPrincipal로 유저 정보 저장되었는지 체크 …

### DIFF
--- a/src/main/java/com/cloudbread/domain/user/api/UserRestController.java
+++ b/src/main/java/com/cloudbread/domain/user/api/UserRestController.java
@@ -1,6 +1,8 @@
 package com.cloudbread.domain.user.api;
 
+import com.cloudbread.auth.oauth2.CustomOAuth2User;
 import com.cloudbread.domain.user.application.UserService;
+import com.cloudbread.domain.user.domain.entity.User;
 import com.cloudbread.domain.user.dto.UserResponseDto;
 import com.cloudbread.domain.user.dto.UserResponseDto.Example;
 import com.cloudbread.domain.user.exception.annotation.UserExist;
@@ -8,6 +10,8 @@ import com.cloudbread.global.common.code.status.SuccessStatus;
 import com.cloudbread.global.common.response.BaseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +33,21 @@ public class UserRestController {
         UserResponseDto.Example result = userService.exampleMethod(userId);
 
         return BaseResponse.onSuccess(SuccessStatus.USER_EXAMPLE_SUCCESS, result);
+    }
+
+    // SpringContextHolder에 담긴 인증정보가 잘 보이는지 체크
+    @GetMapping("/me")
+    public ResponseEntity<UserResponseDto.SecurityContextDto> getMyInfo(
+            @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+            ){
+        User user = customOAuth2User.getUser();
+
+        UserResponseDto.SecurityContextDto result = UserResponseDto.SecurityContextDto.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .build();
+
+        return ResponseEntity.ok(result);
     }
 
 

--- a/src/main/java/com/cloudbread/domain/user/dto/UserResponseDto.java
+++ b/src/main/java/com/cloudbread/domain/user/dto/UserResponseDto.java
@@ -16,4 +16,12 @@ public class UserResponseDto {
         private boolean isAdult;
     }
 
+    @Builder
+    @AllArgsConstructor
+    @Getter
+    public static class SecurityContextDto {
+        private Long id;
+        private String email;
+    }
+
 }


### PR DESCRIPTION
## 📌 연관 이슈
- issue #7

## 🌱 PR 요약
- UserRestController에 /api/users/me API를 추가해, @AuthenticationPrincipal로부터 스프링 컨텍스트 홀더에 인증정보가 잘 담겼는지 확인하는 로직을 구현했습니다.

## 📸 스크린샷
1. http://localhost:8080/oauth2/authorization/kakao 로 카카오 로그인 요청을 보냅니다.
<img width="1161" height="161" alt="image" src="https://github.com/user-attachments/assets/f46d0381-2aae-4e2b-b1f0-7188c4e2501c" />
- response body에 accessToken, refreshToken을 잘 담아 보낸 것을 확인할 수 있습니다.

2. 앞선 accessToken을 담아서, 요청을 보낼 때 Authorization 헤더에 Bearer {accessToken}값을 담아 보내면, userId와 email 정보를 알 수 있습니다.
<img width="848" height="526" alt="image" src="https://github.com/user-attachments/assets/e6776db1-030b-4695-822e-ff1310157e02" />

