### PR TITLE
[feat/#7] : google oauth2 구현 추가, 동일한 email이지만 다른 provider일 때, 에러 json 반환

### DIFF
--- a/src/main/java/com/cloudbread/auth/oauth2/dto/GoogleResponse.java
+++ b/src/main/java/com/cloudbread/auth/oauth2/dto/GoogleResponse.java
@@ -1,0 +1,35 @@
+package com.cloudbread.auth.oauth2.dto;
+
+import lombok.RequiredArgsConstructor;
+
+import java.util.Map;
+
+// Google oauth2 응답에서 필요한 정보를 추출하는 역할
+@RequiredArgsConstructor
+public class GoogleResponse implements OAuth2Response {
+    private final Map<String, Object> attributes;
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("sub").toString();
+    } // 고유 식별자
+
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString(); // 이메일
+    }
+
+    @Override
+    public String getNickName() {
+        return attributes.get("name").toString(); // 닉네임
+    }
+
+    @Override
+    public String getProfileImage() {
+        return attributes.get("picture").toString(); // 프로필 사진 URL
+    }
+}

--- a/src/main/java/com/cloudbread/auth/oauth2/exception/CustomOAuth2FailureHandler.java
+++ b/src/main/java/com/cloudbread/auth/oauth2/exception/CustomOAuth2FailureHandler.java
@@ -1,0 +1,35 @@
+package com.cloudbread.auth.oauth2.exception;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Component
+public class CustomOAuth2FailureHandler implements AuthenticationFailureHandler {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request,
+                                        HttpServletResponse response,
+                                        AuthenticationException exception)
+            throws IOException, ServletException {
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType("application/json; charset=UTF-8");
+
+        Map<String, String> errorResponse = new HashMap<>();
+        errorResponse.put("error", "OAuth Login Failed");
+        errorResponse.put("message", exception.getMessage());
+
+        response.getWriter().write(objectMapper.writeValueAsString(errorResponse));
+    }
+}

--- a/src/main/java/com/cloudbread/auth/oauth2/exception/OauthProviderMismatchException.java
+++ b/src/main/java/com/cloudbread/auth/oauth2/exception/OauthProviderMismatchException.java
@@ -1,0 +1,10 @@
+package com.cloudbread.auth.oauth2.exception;
+
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.OAuth2Error;
+
+public class OauthProviderMismatchException extends OAuth2AuthenticationException {
+    public OauthProviderMismatchException(String message) {
+        super(new OAuth2Error("provider_mismatch", message, null));
+    }
+}

--- a/src/main/java/com/cloudbread/domain/user/domain/enums/OauthProvider.java
+++ b/src/main/java/com/cloudbread/domain/user/domain/enums/OauthProvider.java
@@ -5,9 +5,15 @@ public enum OauthProvider {
     GOOGLE, NAVER, KAKAO;
 
     public static OauthProvider fromRegistrationId(String registrationId){
+        System.out.println(">>> registrationId 받음: " + registrationId);  // 로그 추가
+
+        if (registrationId == null || registrationId.isBlank()) {
+            throw new IllegalArgumentException("registrationId is null or blank");
+        }
+
         switch (registrationId.toLowerCase()) {
             case "kakao": return KAKAO;
-//            case "google": return GOOGLE;
+            case "google": return GOOGLE;
 //            case "naver": return NAVER;
             default: throw new IllegalArgumentException("Unknown registrationId: " + registrationId);
         }

--- a/src/main/java/com/cloudbread/global/common/code/status/ErrorStatus.java
+++ b/src/main/java/com/cloudbread/global/common/code/status/ErrorStatus.java
@@ -17,8 +17,12 @@ public enum ErrorStatus implements BaseErrorCode {
     _FORBIDDEN(HttpStatus.FORBIDDEN, "COMMON403", "금지된 요청입니다."),
 
     // --- User ---
-    NO_SUCH_USER(HttpStatus.BAD_REQUEST, "USER_404", "User가 존재하지 않습니다.")
+    NO_SUCH_USER(HttpStatus.BAD_REQUEST, "USER_404", "User가 존재하지 않습니다."),
+
+
+
     ;
+
 
     private final HttpStatus httpStatus;
     private final String code;

--- a/src/main/java/com/cloudbread/global/config/SecurityConfig.java
+++ b/src/main/java/com/cloudbread/global/config/SecurityConfig.java
@@ -4,10 +4,10 @@ import com.cloudbread.auth.jwt.JwtAuthorizationFilter;
 import com.cloudbread.auth.jwt.JwtUtil;
 import com.cloudbread.auth.oauth2.CustomOAuth2UserService;
 import com.cloudbread.auth.oauth2.OAuth2LoginSuccessHandler;
+import com.cloudbread.auth.oauth2.exception.CustomOAuth2FailureHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpStatus;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
@@ -24,6 +24,7 @@ public class SecurityConfig {
     private final CustomOAuth2UserService customOAuth2UserService;
     private final OAuth2LoginSuccessHandler oAuth2LoginSuccessHandler;
     private final JwtUtil jwtUtil;
+    private final CustomOAuth2FailureHandler customOAuth2FailureHandler;
 
     private final CorsConfigurationSource corsConfigurationSource;
     @Bean
@@ -40,6 +41,7 @@ public class SecurityConfig {
                         .userInfoEndpoint(userInfoEndpoint ->
                                 userInfoEndpoint.userService(customOAuth2UserService))
                         .successHandler(oAuth2LoginSuccessHandler)
+                        .failureHandler(customOAuth2FailureHandler) // 실패 시 핸들러 등록
 
                 )
                 .sessionManagement(session ->
@@ -49,7 +51,7 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/swagger-ui/**", "/v3/api-docs/**",
                                 "/api/users/example/{user-id}", // 패키지 구조 예제 코드
-                                "/oauth2/authorization/kakao", // 카카오 로그인 요청
+                                "/oauth2/authorization/**", // 카카오 로그인 요청 (/kakao, /google
                                 "/login/oauth2/code/**" // 카카오 인증 콜백
                         )
                         .permitAll()


### PR DESCRIPTION
## 📌 연관 이슈
- issue #7 

## 🌱 PR 요약
- 구글 oauth2 로그인을 구현했습니다.
- 동일한 email이지만, 다른 provider일 때 "해당 이메일은 다른 계정으로 이미 가입되어 있습니다." 라는 에러메세지를 띄웁니다.


## 📸 스크린샷
1. 구글 oauth2 로그인 구현 (http://localhost:8080/oauth2/authorization/google 로 요청보내기)
<img width="1057" height="178" alt="image" src="https://github.com/user-attachments/assets/a31a8411-968f-4cd0-a397-a483d66e0260" />


2. 동일한 email이지만, 다른 provider일 때 예외처리
<img width="455" height="109" alt="image" src="https://github.com/user-attachments/assets/f8bfbdcf-b6e2-4107-aa83-5370e78cd814" />

