### PR TITLE
[Feat/#47] : es로부터 음식데이터가 빈 리스트가 온다면, 자동완성/검색 api 호출

### DIFF
--- a/src/main/java/com/cloudbread/domain/food/api/FoodQueryController.java
+++ b/src/main/java/com/cloudbread/domain/food/api/FoodQueryController.java
@@ -1,0 +1,30 @@
+package com.cloudbread.domain.food.api;
+
+import com.cloudbread.domain.food.application.FoodQueryService;
+import com.cloudbread.domain.food.dto.FoodResponse;
+import com.cloudbread.global.common.code.status.SuccessStatus;
+import com.cloudbread.global.common.response.BaseResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/foods")
+@RequiredArgsConstructor
+public class FoodQueryController {
+    private final FoodQueryService foodQueryService;
+
+    @GetMapping("/suggest")
+    public BaseResponse<List<FoodResponse.SuggestItem>> suggest(
+            @RequestParam("q") String q,
+            @RequestParam(value = "limit", defaultValue = "10") int limit
+    ) {
+        var result = foodQueryService.suggest(q, limit);
+        return BaseResponse.onSuccess(SuccessStatus._OK, result);
+    }
+
+}

--- a/src/main/java/com/cloudbread/domain/food/application/FoodQueryService.java
+++ b/src/main/java/com/cloudbread/domain/food/application/FoodQueryService.java
@@ -1,0 +1,9 @@
+package com.cloudbread.domain.food.application;
+
+import com.cloudbread.domain.food.dto.FoodResponse;
+
+import java.util.List;
+
+public interface FoodQueryService {
+    List<FoodResponse.SuggestItem> suggest(String q, int limit);
+}

--- a/src/main/java/com/cloudbread/domain/food/application/FoodQueryServiceImpl.java
+++ b/src/main/java/com/cloudbread/domain/food/application/FoodQueryServiceImpl.java
@@ -1,0 +1,30 @@
+package com.cloudbread.domain.food.application;
+
+import com.cloudbread.domain.food.domain.entity.Food;
+import com.cloudbread.domain.food.domain.repository.FoodRepository;
+import com.cloudbread.domain.food.dto.FoodResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class FoodQueryServiceImpl implements FoodQueryService {
+    private final FoodRepository foodRepository;
+    @Override
+    @Transactional(readOnly = true)
+    public List<FoodResponse.SuggestItem> suggest(String q, int limit) {
+        var page = PageRequest.of(0, Math.max(1, limit));
+        var foods = foodRepository.searchByNameContainsSuggest(q, page);
+
+        return foods.stream()
+                .map(f -> new FoodResponse.SuggestItem(
+                        f.getId(), f.getName(), f.getCategory(), f.getCalories()
+                ))
+                .toList();
+    }
+}

--- a/src/main/java/com/cloudbread/domain/food/domain/repository/FoodRepository.java
+++ b/src/main/java/com/cloudbread/domain/food/domain/repository/FoodRepository.java
@@ -18,4 +18,15 @@ public interface FoodRepository extends JpaRepository<Food, Long> {
     default List<Food> searchByNameContains(String q, int size) {
         return searchByNameContains(q, org.springframework.data.domain.PageRequest.of(0, size));
     }
+
+    @Query("""
+        select f from Food f
+        where lower(f.name) like lower(concat('%', :q, '%'))
+        order by 
+          case when lower(f.name) = lower(:q) then 0
+               when lower(f.name) like lower(concat(:q, '%')) then 1
+               else 2 end,
+          f.name asc
+    """)
+    List<Food> searchByNameContainsSuggest(@Param("q") String q, Pageable pageable);
 }

--- a/src/main/java/com/cloudbread/domain/food/dto/FoodResponse.java
+++ b/src/main/java/com/cloudbread/domain/food/dto/FoodResponse.java
@@ -1,0 +1,5 @@
+package com.cloudbread.domain.food.dto;
+
+public class FoodResponse {
+    public record SuggestItem(Long foodId, String name, String category, java.math.BigDecimal calories) {}
+}

--- a/src/main/java/com/cloudbread/domain/photo_analyses/domain/entity/PhotoAnalysis.java
+++ b/src/main/java/com/cloudbread/domain/photo_analyses/domain/entity/PhotoAnalysis.java
@@ -82,9 +82,14 @@ public class PhotoAnalysis extends BaseEntity {
         this.photoAnalysisStatus = status;
     }
 
-    public void updateCandidatesJson(String json) {
+//    public void updateCandidatesJson(String json) {
+//        this.candidatesJson = json;
+//        this.photoAnalysisStatus = PhotoAnalysisStatus.CANDIDATES_READY;
+//    }
+
+    public void updateCandidates(String json, PhotoAnalysisStatus status) {
         this.candidatesJson = json;
-        this.photoAnalysisStatus = PhotoAnalysisStatus.CANDIDATES_READY;
+        this.photoAnalysisStatus = status; // CANDIDATES_READY or NO_CANDIDATES
     }
 }
 

--- a/src/main/java/com/cloudbread/domain/photo_analyses/domain/enums/PhotoAnalysisStatus.java
+++ b/src/main/java/com/cloudbread/domain/photo_analyses/domain/enums/PhotoAnalysisStatus.java
@@ -5,7 +5,8 @@ public enum PhotoAnalysisStatus {
     LABELED, // AI가 음식명 라벨 반환
     CANDIDATES_READY, // ES 후보 3개 뽑아 DB 저장 완료
     USER_CONFIRMED, // 유저가 최종 1개 선택 완료
-    FAILED // 중간 실패
+    FAILED, // 실패
+    NO_CANDIDATES,        // 후보 없음
 }
 
 

--- a/src/main/java/com/cloudbread/global/config/SecurityConfig.java
+++ b/src/main/java/com/cloudbread/global/config/SecurityConfig.java
@@ -65,7 +65,8 @@ public class SecurityConfig {
                                 "/seed/**",
                                 "/api/ai/**", // ai가 백엔드로 요청보낼 때, 토큰 요청하지 않도록,
                                 "/uploads/**",
-                                "/api/photo-analyses/*/events" // 프론트가 이벤트 구독하는 api
+                                "/api/photo-analyses/*/events", // 프론트가 이벤트 구독하는 api,
+                                "/api/foods/suggest" // 음식 검색 api
                         )
                         .permitAll()
                         .anyRequest().authenticated() // 그외 요청은 허가된 사람만 인가


### PR DESCRIPTION

## 📌 연관 이슈
- issue #47

## 🌱 PR 요약
- ES로부터 음식데이터가 빈 값이 온다면, enum을 NO_CANDIDATES로 업데이트
- 빈 음식리스트인 경우, 프론트는 검색 api를 이용해서 음식을 선택해주세요!
